### PR TITLE
Avoiding unintended OL by escaping in paragraphs

### DIFF
--- a/src/marge/core.cljc
+++ b/src/marge/core.cljc
@@ -7,7 +7,7 @@
   You can also view [blog posts] (http://markw.xyz/tags/marge/) about marge
   "
   {:author "Mark Woodhall"}
-  (:require [clojure.string :refer [join triml]]
+  (:require [clojure.string :refer [join triml] :as s]
             [marge.util :refer [balance-at balance-when longest]]))
 
 (declare pair->markdown list- ordered-list unordered-list)
@@ -18,6 +18,21 @@
 (defonce ^:private whitespace " ")
 (defonce ^:private rule (str divider divider divider))
 (defonce ^:private column-start " | ") ;; We trim the leading space when rendering a row
+
+(def ^:private ol-re #"^(\d+)\. ")
+
+(defn- escape-ol
+  "Takes a string s and escapes a dot if neccessary."
+  [s]
+  ;; using fn form here for compat between clj & cljs
+  (s/replace s
+             ol-re
+             (fn [m]
+               (str (second m) "\\. "))))
+
+(defn- paragraph
+  [value]
+  (str (escape-ol value) linebreak))
 
 (defn- header
   [depth value]
@@ -170,7 +185,7 @@
   (case node
     :br (if (= value :br) (str linebreak linebreak) linebreak)
     :hr (if (= value :hr) (str rule linebreak rule) rule)
-    :p (str value linebreak)
+    :p  (paragraph value)
     :h1 (header 1 value)
     :h2 (header 2 value)
     :h3 (header 3 value)

--- a/test/marge/core_test.cljc
+++ b/test/marge/core_test.cljc
@@ -5,7 +5,16 @@
 (t/deftest paragraph
   (t/testing "p produces expected string"
     (t/is (= "Paragraph\n"
-             (markdown [:p "Paragraph"])))))
+             (markdown [:p "Paragraph"]))))
+  (t/testing "p escapes unintended ordered list"
+    (t/is (= "1 abc\n"
+             (markdown [:p "1 abc"])))
+    (t/is (= "1\\. abc\n"
+             (markdown [:p "1. abc"])))
+    (t/is (= "9999\\. abc\n"
+             (markdown [:p "9999. abc"])))
+    (t/is (= "9999.abc\n"
+             (markdown [:p "9999.abc"])))))
 
 (t/deftest rulers
   (t/testing "hr produces expected string"


### PR DESCRIPTION
* If the beginning of a paragraph is "number-period-space", the period
  gets escaped with a backslash to avoid an ordered list detection
  when the markdown renders.
* CLJ and CLJS treat backslashes differently that's why we use the
  form with a fn of the matcher here.

I don't know if you like the idea at all. One could argue that more escapes would be necessary and also the library users could be forced to handle such escapes themselves. The idea here is that such things can be subtle and would best be handled at library level. Not sure what else we will find down that rabbit hole.