### PR TITLE
Add functionality to embed html in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ Sometimes you might want to place an anchor that you link to later.
 | ----- | ----------- |
 | link  | [text](url) |
 
+### HTML Inside Markdown
+
+You can generate html inside your markdown using Hiccup syntax, the rendering for this uses Hiccup for Clojure or Hiccups for ClojureScript.
+
+```clojure
+(markdown [:p 
+           [:normal "When I want to search for things I go to "
+            :html [:a {:href "http://google.com"} "google"]]])
+```
+
+When I want to search for things I go to <a href="http://google.com">google</a>
+
 ### Composition
 
 ```clojure

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,10 @@
 {:paths ["src"]
  :deps
  {org.clojure/clojure {:mvn/version "1.9.0"}
-  org.clojure/clojurescript {:mvn/version "1.9.946"}}
+  org.clojure/clojurescript {:mvn/version "1.9.946"}
+  
+  hiccup {:mvn/version "1.0.5"}
+  hiccups {:mvn/version "0.3.0"}}
 
  :aliases
  {:dev

--- a/test/marge/core_test.cljc
+++ b/test/marge/core_test.cljc
@@ -226,6 +226,13 @@
                          "Price"
                          []]])))))
 
+(t/deftest embedded-html
+  (t/testing "nodes with embedded html return expected result"
+    (t/is (= "When I want to search for things I go to <a href=\"http://google.com\">google</a>\n"
+             (markdown [:p 
+                        [:normal "When I want to search for things I go to "
+                         :html [:a {:href "http://google.com"} "google"]]])))))
+
 (t/deftest composing-nodes
   (t/testing "composing multiple nodes with line breaks"
     (t/is (= "# Header\n\n\n---1. First item\n2. Second item\n\n---## Header 2\n"


### PR DESCRIPTION
This PR add support for embedding html in markdown using `:html`. The generation of html is done by Hiccup for Clojure and Hiccups for ClojureScript. 

As part of this I have also tidied up clojure.string requires.